### PR TITLE
Headless

### DIFF
--- a/resource.robot
+++ b/resource.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation     A resource file for checking on a Tesla Account.
-Library           SeleniumLibrary
+Library           SeleniumLibrary     run_on_failure=NOTHING
 
 *** Variables ***
 ${USERNAME}       user@example.com

--- a/resource.robot
+++ b/resource.robot
@@ -13,6 +13,10 @@ ${PUSHBULLET KEY}    x.12345678911234567892123456789312
 
 *** Keywords ***
 Open Browser To Login Page
+    ${chrome_options} =     Evaluate    sys.modules['selenium.webdriver'].ChromeOptions()    sys, selenium.webdriver
+    Call Method    ${chrome_options}   add_argument    headless
+    Call Method    ${chrome_options}   add_argument    disable-gpu
+    ${options}=     Call Method     ${chrome_options}    to_capabilities
     Open Browser    ${LOGIN URL}    ${BROWSER}
     Maximize Browser Window
     Set Selenium Speed    ${DELAY}


### PR DESCRIPTION
I started using this to check for the VIN on a Model Y reservation.

-Running the program from a cron job would fail unless I configured selenium to run in headless mode.

-I also dislabed the screenshot on failures so that it didn't fill up the hard drive with images every time the program ran and didn't find a VIN.